### PR TITLE
Make eg-next examples compile on 0.7 again

### DIFF
--- a/eg-next/examples/analog-clock.rs
+++ b/eg-next/examples/analog-clock.rs
@@ -9,7 +9,7 @@
 use chrono::{Local, Timelike};
 use core::f32::consts::PI;
 use embedded_graphics::{
-    mono_font::{ascii::Font9x15, MonoTextStyle},
+    mono_font::{ascii::FONT_9X15, MonoTextStyle},
     pixelcolor::BinaryColor,
     prelude::*,
     primitives::{Circle, Line, PrimitiveStyle, PrimitiveStyleBuilder, Rectangle},
@@ -138,8 +138,11 @@ where
     D: DrawTarget<Color = BinaryColor>,
 {
     // Create a styled text object for the time text.
-    let mut text = Text::new(&time_str, Point::zero())
-        .into_styled(MonoTextStyle::new(Font9x15, BinaryColor::Off));
+    let mut text = Text::new(
+        &time_str,
+        Point::zero(),
+        MonoTextStyle::new(&FONT_9X15, BinaryColor::Off),
+    );
 
     // Move text to be centered between the 12 o'clock point and the center of the clock face.
     text.translate_mut(
@@ -159,7 +162,9 @@ where
     .draw(target)?;
 
     // Draw the text after the background is drawn.
-    text.draw(target)
+    text.draw(target)?;
+
+    Ok(())
 }
 
 fn main() -> Result<(), core::convert::Infallible> {

--- a/eg-next/examples/hello-world.rs
+++ b/eg-next/examples/hello-world.rs
@@ -3,7 +3,7 @@
 //! A simple hello world example displaying some primitive shapes and some text underneath.
 
 use embedded_graphics::{
-    mono_font::{ascii::FONT_6X9, MonoTextStyle},
+    mono_font::{ascii::FONT_6X10, MonoTextStyle},
     pixelcolor::BinaryColor,
     prelude::*,
     primitives::{
@@ -28,7 +28,7 @@ fn main() -> Result<(), std::convert::Infallible> {
         .stroke_alignment(StrokeAlignment::Inside)
         .build();
     let fill = PrimitiveStyle::with_fill(BinaryColor::On);
-    let character_style = MonoTextStyle::new(&FONT_6X9, BinaryColor::On);
+    let character_style = MonoTextStyle::new(&FONT_6X10, BinaryColor::On);
 
     let yoffset = 14;
 

--- a/eg-next/examples/hello-world.rs
+++ b/eg-next/examples/hello-world.rs
@@ -3,13 +3,13 @@
 //! A simple hello world example displaying some primitive shapes and some text underneath.
 
 use embedded_graphics::{
-    mono_font::{ascii::Font5x8, MonoTextStyle},
+    mono_font::{ascii::FONT_6X9, MonoTextStyle},
     pixelcolor::BinaryColor,
     prelude::*,
     primitives::{
         Circle, PrimitiveStyle, PrimitiveStyleBuilder, Rectangle, StrokeAlignment, Triangle,
     },
-    text::Text,
+    text::{Alignment, Text},
 };
 use embedded_graphics_simulator::{
     BinaryColorTheme, OutputSettingsBuilder, SimulatorDisplay, Window,
@@ -21,46 +21,51 @@ fn main() -> Result<(), std::convert::Infallible> {
 
     // Create styles used by the drawing operations.
     let thin_stroke = PrimitiveStyle::with_stroke(BinaryColor::On, 1);
-    let thick_stroke = PrimitiveStyleBuilder::new()
+    let thick_stroke = PrimitiveStyle::with_stroke(BinaryColor::On, 3);
+    let border_stroke = PrimitiveStyleBuilder::new()
         .stroke_color(BinaryColor::On)
         .stroke_width(3)
         .stroke_alignment(StrokeAlignment::Inside)
         .build();
     let fill = PrimitiveStyle::with_fill(BinaryColor::On);
-    let text_style = MonoTextStyle::new(Font5x8, BinaryColor::On);
+    let character_style = MonoTextStyle::new(&FONT_6X9, BinaryColor::On);
 
     let yoffset = 14;
 
     // Draw a 3px wide outline around the display.
-    Rectangle::new(Point::zero(), display.size())
-        .into_styled(thick_stroke)
+    display
+        .bounding_box()
+        .into_styled(border_stroke)
         .draw(&mut display)?;
 
     // Draw a triangle.
     Triangle::new(
-        Point::new(18, 17 + yoffset),
-        Point::new(18 + 16, 17 + yoffset),
-        Point::new(18 + 8, yoffset),
+        Point::new(16, 16 + yoffset),
+        Point::new(16 + 16, 16 + yoffset),
+        Point::new(16 + 8, yoffset),
     )
     .into_styled(thin_stroke)
     .draw(&mut display)?;
 
     // Draw a filled square
-    Rectangle::new(Point::new(55, yoffset), Size::new(18, 18))
+    Rectangle::new(Point::new(52, yoffset), Size::new(16, 16))
         .into_styled(fill)
         .draw(&mut display)?;
 
     // Draw a circle with a 3px wide stroke.
-    Circle::new(Point::new(92, yoffset), 18)
+    Circle::new(Point::new(88, yoffset), 17)
         .into_styled(thick_stroke)
         .draw(&mut display)?;
 
     // Draw centered text.
     let text = "embedded-graphics";
-    let width = text.len() as i32 * 6;
-    Text::new(text, Point::new(64 - width / 2, 43))
-        .into_styled(text_style)
-        .draw(&mut display)?;
+    Text::with_alignment(
+        text,
+        display.bounding_box().center() + Point::new(0, 15),
+        character_style,
+        Alignment::Center,
+    )
+    .draw(&mut display)?;
 
     let output_settings = OutputSettingsBuilder::new()
         .theme(BinaryColorTheme::OledBlue)

--- a/eg-next/examples/image-sub-image.rs
+++ b/eg-next/examples/image-sub-image.rs
@@ -8,7 +8,7 @@
 
 use embedded_graphics::{
     image::Image,
-    mono_font::{ascii::Font6x9, MonoTextStyle},
+    mono_font::{ascii::FONT_6X9, MonoTextStyle},
     pixelcolor::Rgb888,
     prelude::*,
     primitives::Rectangle,
@@ -38,19 +38,11 @@ fn main() -> Result<(), core::convert::Infallible> {
     Image::new(&tile_c, Point::new(100, 310)).draw(&mut display)?;
 
     // Draw labels.
-    let text_style = MonoTextStyle::new(Font6x9, Rgb888::WHITE);
-    Text::new("TGA image", Point::new(10, 70))
-        .into_styled(text_style)
-        .draw(&mut display)?;
-    Text::new("Tile A", Point::new(10, 200))
-        .into_styled(text_style)
-        .draw(&mut display)?;
-    Text::new("Tile B", Point::new(10, 270))
-        .into_styled(text_style)
-        .draw(&mut display)?;
-    Text::new("Tile C", Point::new(10, 340))
-        .into_styled(text_style)
-        .draw(&mut display)?;
+    let text_style = MonoTextStyle::new(&FONT_6X9, Rgb888::WHITE);
+    Text::new("TGA image", Point::new(10, 70), text_style).draw(&mut display)?;
+    Text::new("Tile A", Point::new(10, 200), text_style).draw(&mut display)?;
+    Text::new("Tile B", Point::new(10, 270), text_style).draw(&mut display)?;
+    Text::new("Tile C", Point::new(10, 340), text_style).draw(&mut display)?;
 
     let output_settings = OutputSettingsBuilder::new().scale(2).build();
     Window::new("Sub images", &output_settings).show_static(&display);

--- a/eg-next/examples/line-thickness.rs
+++ b/eg-next/examples/line-thickness.rs
@@ -10,7 +10,7 @@ extern crate embedded_graphics;
 extern crate embedded_graphics_simulator;
 
 use embedded_graphics::{
-    mono_font::{ascii::Font6x9, MonoTextStyle},
+    mono_font::{ascii::FONT_6X9, MonoTextStyle},
     pixelcolor::Rgb888,
     prelude::*,
     primitives::{Line, PrimitiveStyle},
@@ -42,8 +42,8 @@ fn draw(
             position.y - start.y
         ),
         Point::new(5, 10),
+        MonoTextStyle::new(&FONT_6X9, Rgb888::MAGENTA),
     )
-    .into_styled(MonoTextStyle::new(Font6x9, Rgb888::MAGENTA))
     .draw(display)?;
 
     Line::new(start, position)

--- a/eg-next/examples/primitives-ellipse.rs
+++ b/eg-next/examples/primitives-ellipse.rs
@@ -8,7 +8,7 @@
 //! rendering.
 
 use embedded_graphics::{
-    mono_font::{ascii::Font6x9, MonoTextStyle},
+    mono_font::{ascii::FONT_6X9, MonoTextStyle},
     pixelcolor::Rgb888,
     prelude::*,
     primitives::*,
@@ -29,8 +29,8 @@ fn draw_ellipse(
     Text::new(
         &format!("S: {}\n{:?}", stroke_width, size),
         Point::new(5, 10),
+        MonoTextStyle::new(&FONT_6X9, Rgb888::MAGENTA),
     )
-    .into_styled(MonoTextStyle::new(Font6x9, Rgb888::MAGENTA))
     .draw(display)
     .unwrap();
 

--- a/eg-next/examples/primitives-stroke-alignment.rs
+++ b/eg-next/examples/primitives-stroke-alignment.rs
@@ -7,7 +7,7 @@
 
 use core::convert::Infallible;
 use embedded_graphics::{
-    mono_font::{ascii::Font6x12, MonoTextStyle},
+    mono_font::{ascii::FONT_7X13, MonoTextStyle},
     pixelcolor::Rgb888,
     prelude::*,
     primitives::{
@@ -77,25 +77,22 @@ fn update(
     }
 
     let text_offset = Point::new(0, 8) + Size::new(PADDING, 10);
+    let text_style = MonoTextStyle::new(&FONT_7X13, Rgb888::WHITE);
     let column_offset = Size::new(SIZE + PADDING, 0);
-    Text::new("Inside", text_offset)
-        .into_styled(MonoTextStyle::new(Font6x12, Rgb888::WHITE))
-        .draw(display)?;
+    Text::new("Inside", text_offset, text_style).draw(display)?;
 
-    Text::new("Center\n(Default)", text_offset + column_offset)
-        .into_styled(MonoTextStyle::new(Font6x12, Rgb888::WHITE))
-        .draw(display)?;
+    Text::new("Center\n(Default)", text_offset + column_offset, text_style).draw(display)?;
 
-    Text::new("Outside", text_offset + column_offset * 2)
-        .into_styled(MonoTextStyle::new(Font6x12, Rgb888::WHITE))
-        .draw(display)?;
+    Text::new("Outside", text_offset + column_offset * 2, text_style).draw(display)?;
 
     Text::new(
         "Click to toggle shape outline",
         Point::new(PADDING as i32, 340),
+        text_style,
     )
-    .into_styled(MonoTextStyle::new(Font6x12, Rgb888::WHITE))
-    .draw(display)
+    .draw(display)?;
+
+    Ok(())
 }
 
 fn main() -> Result<(), Infallible> {

--- a/eg-next/examples/progress.rs
+++ b/eg-next/examples/progress.rs
@@ -3,11 +3,11 @@
 //! An example displaying a progress circle.
 
 use embedded_graphics::{
-    mono_font::{ascii::Font10x20, MonoTextStyle},
+    mono_font::{ascii::FONT_10X20, MonoTextStyle},
     pixelcolor::BinaryColor,
     prelude::*,
     primitives::{Arc, PrimitiveStyleBuilder, StrokeAlignment},
-    text::{HorizontalAlignment, Text, TextStyleBuilder, VerticalAlignment},
+    text::{Alignment, Baseline, Text, TextStyleBuilder},
 };
 use embedded_graphics_simulator::{
     BinaryColorTheme, OutputSettingsBuilder, SimulatorDisplay, SimulatorEvent, Window,
@@ -24,11 +24,10 @@ fn main() -> Result<(), std::convert::Infallible> {
         .stroke_width(5)
         .stroke_alignment(StrokeAlignment::Inside)
         .build();
-    let character_style = MonoTextStyle::new(Font10x20, BinaryColor::On);
+    let character_style = MonoTextStyle::new(&FONT_10X20, BinaryColor::On);
     let text_style = TextStyleBuilder::new()
-        .character_style(character_style)
-        .vertical_alignment(VerticalAlignment::Center)
-        .horizontal_alignment(HorizontalAlignment::Center)
+        .baseline(Baseline::Middle)
+        .alignment(Alignment::Center)
         .build();
 
     let output_settings = OutputSettingsBuilder::new()
@@ -51,9 +50,13 @@ fn main() -> Result<(), std::convert::Infallible> {
 
         // Draw centered text.
         let text = format!("{}%", progress);
-        Text::new(&text, display.bounding_box().center())
-            .into_styled(text_style)
-            .draw(&mut display)?;
+        Text::with_text_style(
+            &text,
+            display.bounding_box().center(),
+            character_style,
+            text_style,
+        )
+        .draw(&mut display)?;
 
         window.update(&display);
 

--- a/eg-next/examples/text-fonts-signs.rs
+++ b/eg-next/examples/text-fonts-signs.rs
@@ -4,7 +4,7 @@
 
 use embedded_graphics::{
     mono_font::{
-        latin1::{Font10x20, Font6x12, Font6x9, Font8x13},
+        latin1::{FONT_10X20, FONT_6X12, FONT_6X9, FONT_8X13},
         MonoTextStyle,
     },
     pixelcolor::BinaryColor,
@@ -19,24 +19,36 @@ fn main() -> Result<(), core::convert::Infallible> {
     let test_text  = "¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ";
 
     // Show smallest font with black font on white background (default value for fonts)
-    Text::new(&format!("Font6x9 {}", test_text), Point::new(15, 15))
-        .into_styled(MonoTextStyle::new(Font6x9, BinaryColor::On))
-        .draw(&mut display)?;
+    Text::new(
+        &format!("Font6x9 {}", test_text),
+        Point::new(15, 15),
+        MonoTextStyle::new(&FONT_6X9, BinaryColor::On),
+    )
+    .draw(&mut display)?;
 
     // Show 6x12 font
-    Text::new(&format!("Font6x12 {}", test_text), Point::new(15, 30))
-        .into_styled(MonoTextStyle::new(Font6x12, BinaryColor::On))
-        .draw(&mut display)?;
+    Text::new(
+        &format!("Font6x12 {}", test_text),
+        Point::new(15, 30),
+        MonoTextStyle::new(&FONT_6X12, BinaryColor::On),
+    )
+    .draw(&mut display)?;
 
     // Show 8x13 Font
-    Text::new(&format!("Font8x13 {}", test_text), Point::new(15, 45))
-        .into_styled(MonoTextStyle::new(Font8x13, BinaryColor::On))
-        .draw(&mut display)?;
+    Text::new(
+        &format!("Font8x13 {}", test_text),
+        Point::new(15, 45),
+        MonoTextStyle::new(&FONT_8X13, BinaryColor::On),
+    )
+    .draw(&mut display)?;
 
     // Show 10x20 Font
-    Text::new(&format!("Font10x20 {}", test_text), Point::new(15, 65))
-        .into_styled(MonoTextStyle::new(Font10x20, BinaryColor::On))
-        .draw(&mut display)?;
+    Text::new(
+        &format!("Font10x20 {}", test_text),
+        Point::new(15, 65),
+        MonoTextStyle::new(&FONT_10X20, BinaryColor::On),
+    )
+    .draw(&mut display)?;
 
     let output_settings = OutputSettingsBuilder::new().scale(1).build();
     Window::new("Fonts", &output_settings).show_static(&display);

--- a/eg-next/examples/text-fonts.rs
+++ b/eg-next/examples/text-fonts.rs
@@ -4,7 +4,7 @@
 
 use embedded_graphics::{
     mono_font::{
-        ascii::{Font10x20, Font5x8, Font6x12, Font9x15},
+        ascii::{FONT_10X20, FONT_5X8, FONT_6X12, FONT_9X15},
         MonoTextStyle, MonoTextStyleBuilder,
     },
     pixelcolor::BinaryColor,
@@ -17,35 +17,45 @@ fn main() -> Result<(), core::convert::Infallible> {
     let mut display: SimulatorDisplay<BinaryColor> = SimulatorDisplay::new(Size::new(350, 200));
 
     // Show smallest font with black font on white background (default value for fonts)
-    Text::new("Hello World! - default style 6x8", Point::new(15, 15))
-        .into_styled(MonoTextStyle::new(Font5x8, BinaryColor::On))
-        .draw(&mut display)?;
+    Text::new(
+        "Hello World! - default style 5x8",
+        Point::new(15, 15),
+        MonoTextStyle::new(&FONT_5X8, BinaryColor::On),
+    )
+    .draw(&mut display)?;
 
     // Show smallest font with white font on black background
     let style = MonoTextStyleBuilder::new()
-        .font(Font5x8)
+        .font(&FONT_5X8)
         .text_color(BinaryColor::Off)
         .background_color(BinaryColor::On)
         .build();
 
-    Text::new("Hello World! - inverse 6x8", Point::new(15, 30))
-        .into_styled(style)
-        .draw(&mut display)?;
+    Text::new("Hello World! - inverse 5x8", Point::new(15, 30), style).draw(&mut display)?;
 
     // Show 6x12 Font
-    Text::new("Hello 6x12!", Point::new(15, 45))
-        .into_styled(MonoTextStyle::new(Font6x12, BinaryColor::On))
-        .draw(&mut display)?;
+    Text::new(
+        "Hello 6x12!",
+        Point::new(15, 45),
+        MonoTextStyle::new(&FONT_6X12, BinaryColor::On),
+    )
+    .draw(&mut display)?;
 
     // Show 9x15 Font
-    Text::new("Hello 9x15!", Point::new(15, 70))
-        .into_styled(MonoTextStyle::new(Font9x15, BinaryColor::On))
-        .draw(&mut display)?;
+    Text::new(
+        "Hello 9x15!",
+        Point::new(15, 70),
+        MonoTextStyle::new(&FONT_9X15, BinaryColor::On),
+    )
+    .draw(&mut display)?;
 
     // Show 10x20 Font
-    Text::new("Hello 10x20!", Point::new(15, 95))
-        .into_styled(MonoTextStyle::new(Font10x20, BinaryColor::On))
-        .draw(&mut display)?;
+    Text::new(
+        "Hello 10x20!",
+        Point::new(15, 95),
+        MonoTextStyle::new(&FONT_10X20, BinaryColor::On),
+    )
+    .draw(&mut display)?;
 
     let output_settings = OutputSettingsBuilder::new().scale(2).build();
     Window::new("Fonts", &output_settings).show_static(&display);

--- a/eg-next/examples/text-multiline.rs
+++ b/eg-next/examples/text-multiline.rs
@@ -3,7 +3,7 @@
 //! Exercise the font renderer to demonstrate rendering of multiline text
 
 use embedded_graphics::{
-    mono_font::{ascii::Font6x9, MonoTextStyleBuilder},
+    mono_font::{ascii::FONT_6X9, MonoTextStyleBuilder},
     pixelcolor::BinaryColor,
     prelude::*,
     text::Text,
@@ -15,14 +15,17 @@ fn main() -> Result<(), core::convert::Infallible> {
 
     // Show multiline text example
     let style = MonoTextStyleBuilder::new()
-        .font(Font6x9)
+        .font(&FONT_6X9)
         .text_color(BinaryColor::On)
         .background_color(BinaryColor::Off)
         .build();
 
-    Text::new("This is a\nmultiline\nHello World!", Point::new(15, 15))
-        .into_styled(style)
-        .draw(&mut display)?;
+    Text::new(
+        "This is a\nmultiline\nHello World!",
+        Point::new(15, 15),
+        style,
+    )
+    .draw(&mut display)?;
 
     let output_settings = OutputSettingsBuilder::new().scale(2).build();
     Window::new("Fonts", &output_settings).show_static(&display);

--- a/eg-next/examples/text-transparent.rs
+++ b/eg-next/examples/text-transparent.rs
@@ -3,7 +3,7 @@
 //! Demonstrate the background styles and transparency behaviors of different font styles.
 
 use embedded_graphics::{
-    mono_font::{ascii::Font6x9, MonoTextStyleBuilder},
+    mono_font::{ascii::FONT_6X9, MonoTextStyleBuilder},
     pixelcolor::Rgb565,
     prelude::*,
     primitives::{Circle, PrimitiveStyle, Rectangle},
@@ -24,37 +24,40 @@ fn main() -> Result<(), core::convert::Infallible> {
         .draw(&mut display)
         .unwrap();
 
-    Text::new("Hello world! - no background", Point::new(15, 15))
-        .into_styled(
-            // Can also be written in the shorter form: TextStyle::new(Font6x9, Rgb565::WHITE)
-            MonoTextStyleBuilder::new()
-                .font(Font6x9)
-                .text_color(Rgb565::WHITE)
-                .build(),
-        )
-        .draw(&mut display)
-        .unwrap();
+    Text::new(
+        "Hello world! - no background",
+        Point::new(15, 15),
+        // Can also be written in the shorter form: TextStyle::new(&FONT_6X9, Rgb565::WHITE)
+        MonoTextStyleBuilder::new()
+            .font(&FONT_6X9)
+            .text_color(Rgb565::WHITE)
+            .build(),
+    )
+    .draw(&mut display)
+    .unwrap();
 
-    Text::new("Hello world! - filled background", Point::new(15, 30))
-        .into_styled(
-            MonoTextStyleBuilder::new()
-                .font(Font6x9)
-                .text_color(Rgb565::YELLOW)
-                .background_color(Rgb565::BLUE)
-                .build(),
-        )
-        .draw(&mut display)
-        .unwrap();
+    Text::new(
+        "Hello world! - filled background",
+        Point::new(15, 30),
+        MonoTextStyleBuilder::new()
+            .font(&FONT_6X9)
+            .text_color(Rgb565::YELLOW)
+            .background_color(Rgb565::BLUE)
+            .build(),
+    )
+    .draw(&mut display)
+    .unwrap();
 
-    Text::new("Hello world! - inverse background", Point::new(15, 45))
-        .into_styled(
-            MonoTextStyleBuilder::new()
-                .font(Font6x9)
-                .text_color(Rgb565::BLUE)
-                .background_color(Rgb565::YELLOW)
-                .build(),
-        )
-        .draw(&mut display)?;
+    Text::new(
+        "Hello world! - inverse background",
+        Point::new(15, 45),
+        MonoTextStyleBuilder::new()
+            .font(&FONT_6X9)
+            .text_color(Rgb565::BLUE)
+            .background_color(Rgb565::YELLOW)
+            .build(),
+    )
+    .draw(&mut display)?;
 
     let output_settings = OutputSettingsBuilder::new().scale(3).build();
     Window::new("Fonts with transparent background", &output_settings).show_static(&display);


### PR DESCRIPTION
This only touches the hello-world example so it maintains parity with the main e-g lib.rs/README.md example. I guess the other examples can be fixed/upgraded later.