### PR TITLE
Fix build of eg-next

### DIFF
--- a/eg-next/Cargo.toml
+++ b/eg-next/Cargo.toml
@@ -11,12 +11,12 @@ eg-seven-segment = { git = "https://github.com/embedded-graphics/eg-seven-segmen
 embedded-graphics = { git = "https://github.com/embedded-graphics/embedded-graphics.git" }
 embedded-graphics-simulator = { git = "https://github.com/embedded-graphics/simulator.git" }
 embedded-text = { git = "https://github.com/embedded-graphics/embedded-text.git" }
-tinybmp = { git = "https://github.com/embedded-graphics/tinybmp.git" }
-tinytga = { git = "https://github.com/embedded-graphics/tinytga.git" }
+tinybmp = { git = "https://github.com/rfuest/tinybmp.git", branch = "eg-next" }
+tinytga = { git = "https://github.com/rfuest/tinytga.git", branch = "eg-0.9" }
 
 [patch.crates-io]
 embedded-graphics = { git = "https://github.com/embedded-graphics/embedded-graphics.git" }
 embedded-graphics-core = { git = "https://github.com/embedded-graphics/embedded-graphics.git" }
 embedded-text = { git = "https://github.com/embedded-graphics/embedded-text.git" }
-tinybmp = { git = "https://github.com/embedded-graphics/tinybmp.git" }
-tinytga = { git = "https://github.com/embedded-graphics/tinytga.git" }
+tinybmp = { git = "https://github.com/rfuest/tinybmp.git", branch = "eg-next" }
+tinytga = { git = "https://github.com/rfuest/tinytga.git", branch = "eg-0.9" }

--- a/eg-next/examples/text-custom-font.rs
+++ b/eg-next/examples/text-custom-font.rs
@@ -15,7 +15,7 @@ use embedded_graphics_simulator::{
 };
 
 const SEVENT_SEGMENT_FONT: MonoFont = MonoFont {
-    image: ImageRaw::new_binary(include_bytes!("assets/seven-segment-font.raw"), 224),
+    image: ImageRaw::new_const(include_bytes!("assets/seven-segment-font.raw"), Size::new(224, 40)),
     glyph_mapping: &StrGlyphMapping::new("0123456789", 0),
     character_size: Size::new(22, 40),
     character_spacing: 4,


### PR DESCRIPTION
This PR fixes the build of the examples in the `eg-next` directory by temporarily using branches of `tinybmp` and `tinytga`.